### PR TITLE
EVFEVENT post processing is not done for OPM

### DIFF
--- a/QSOURCE/crtfrmstmf.rpgle
+++ b/QSOURCE/crtfrmstmf.rpgle
@@ -274,7 +274,9 @@ CALLP ProcessCommand(CommandString:%SIZE(CommandString):OptCtlBlk:%SIZE(OptCtlBl
                      'CPOP0100':UpdatedString:%SIZE(UpdatedString):UpdatedStringLen:
                      APIError);
 
-if ( %scan( '*EVENTF' : CommandString ) > 0 );
+if ( %scan( '*EVENTF' : CommandString ) > 0 OR  //All ILE compile commands
+     %scan( '*SRCDBG' : CommandString ) > 0 OR  //OPM RPG and COBOL
+     %scan( '*LSTDBG' : CommandString ) > 0);   //OPM CRTSQLRPG/CBL only supports this
   if ( Lib = '*CURLIB' );
     Lib = RetrieveCurrrentLibrary();
   endif;


### PR DESCRIPTION
CRTBNDRPG/CRTBNDCBL/CRTSQLRPG/CRTSQLCBL
use *SRCDBG or *LSTDBG to generate EVFEVENT data

Thanks Brian for integrating the last pull request. It is now possible to use CRTFRMSTMF on OPM RPG and COBOL but the EVFEVENT member did not have its FILEID updated to the IFS file because these commands to not use OPTION(*EVENTF) which was used to trigger this.  I have added the *SRCDBG and *LSTDBG which are the analogous options for those compile commands.
