### PR TITLE
Both IFS CCSID 1208 and 819 map to *JOB mbr CCSID

### DIFF
--- a/QSOURCE/crtfrmstmf.rpgle
+++ b/QSOURCE/crtfrmstmf.rpgle
@@ -246,7 +246,7 @@ CommandString = 'DLTF FILE(QTEMP/QSOURCE)';
 CALLP(E) ExecuteCommand(CommandString:%LEN(CommandString));
 
 // Source physical files that are unicode create problems with CRTPF. Use Job's CCSID instead.
-IF (CCSID = 1208);
+IF (CCSID = 1208 OR CCSID = 819);
     CCSID_c = '*JOB';
 ELSE;
     CCSID_c = %CHAR(CCSID);


### PR DESCRIPTION
When transferring IFS stream files to QTEMP members,
the unicode and ascii CCSIDs are not supported
So we need to map to the *JOB ccsid
as heuristic
This was not done for ASCII 819 before