### PR TITLE
Suppress CPF2105 and no longer support OPM COBOL

### DIFF
--- a/QSOURCE/cl_dltf.clle
+++ b/QSOURCE/cl_dltf.clle
@@ -1,0 +1,8 @@
+    pgm parm(&lib &file)                         
+    dcl &lib type(*char) len(10)                 
+    dcl &file type(*char) len(10)                
+                                                 
+    dltf &lib/&file                              
+    monmsg msgid(CPF2105) exec(rcvmsg rmv(*yes)) 
+    return 
+    endpgm

--- a/QSOURCE/crtfrmstmf.cmd
+++ b/QSOURCE/crtfrmstmf.cmd
@@ -11,7 +11,7 @@
              PARM       KWD(CMD) TYPE(*NAME) LEN(10) RSTD(*YES) +
                           VALUES(CRTCMD CRTBNDCL CRTCLMOD CRTDSPF CRTPRTF +
                           CRTLF CRTPF CRTMNU CRTPNLGRP CRTQMQRY CRTSRVPGM +
-                          CRTWSCST CRTRPGPGM CRTSQLRPG CRTCBLPGM CRTSQLCBL) +
+                          CRTWSCST CRTRPGPGM CRTSQLRP) +
                           MIN(1) CHOICE(*VALUES) PROMPT('Compile command')
 
              PARM       KWD(SRCSTMF) TYPE(*PNAME) LEN(5000) MIN(1) +

--- a/QSOURCE/crtfrmstmf.pnlgrp
+++ b/QSOURCE/crtfrmstmf.pnlgrp
@@ -79,12 +79,6 @@ The CRTRPGPGM compile command is executed.
 :pt.:pk.CRTSQLRPG:epk.
 :pd.
 The CRTSQLRPG compile command is executed.
-:pt.:pk.CRTCBLPGM:epk.
-:pd.
-The CRTCBLPGM compile command is executed.
-:pt.:pk.CRTSQLCBL:epk.
-:pd.
-The CRTSQLCBL compile command is executed.
 :eparml.
 :ehelp.
 

--- a/QSOURCE/crtfrmstmf.rpgle
+++ b/QSOURCE/crtfrmstmf.rpgle
@@ -7,7 +7,6 @@
 
 
 // Compile parameters
-CTL-OPT DFTACTGRP(*NO) ACTGRP(*NEW);
 
 
 // Prototype and Interface for this program
@@ -145,6 +144,11 @@ DCL-PR strerror POINTER EXTPROC('strerror');
     errnum INT(10) VALUE;
 END-PR;
 
+// prototype for the CL_DLTF CLLE module
+dcl-pr cl_dltf;
+   lib char(10) const;
+   file char(10) const;
+end-pr;  
 
 // Standard API error return structure
 DCL-DS APIError QUALIFIED;
@@ -179,9 +183,7 @@ DCL-DS CommandsDS;
     *n CHAR(10) INZ('CRTWSCST');
     *n CHAR(10) INZ('CRTRPGPGM');
     *n CHAR(10) INZ('CRTSQLRPG');
-    *n CHAR(10) INZ('CRTCBLPGM');
-    *n CHAR(10) INZ('CRTSQLCBL');
-    Commands CHAR(10) DIM(16) POS(1);
+    Commands CHAR(10) DIM(14) POS(1);
 END-DS;
 
 DCL-DS ObjTypesDS;
@@ -199,9 +201,7 @@ DCL-DS ObjTypesDS;
     *n CHAR(10) INZ('WSCST');
     *n CHAR(10) INZ('PGM');
     *n CHAR(10) INZ('PGM');
-    *n CHAR(10) INZ('PGM');
-    *n CHAR(10) INZ('PGM');
-    ObjTypes CHAR(10) DIM(16) POS(1);
+    ObjTypes CHAR(10) DIM(14) POS(1);
 END-DS;
 
 
@@ -242,8 +242,7 @@ ENDIF;
 
 
 // Create temporary source file
-CommandString = 'DLTF FILE(QTEMP/QSOURCE)';
-CALLP(E) ExecuteCommand(CommandString:%LEN(CommandString));
+cl_dltf ('QTEMP': 'QSOURCE');   
 
 // Source physical files that are unicode create problems with CRTPF. Use Job's CCSID instead.
 IF (CCSID = 1208 OR CCSID = 819);
@@ -275,8 +274,8 @@ CALLP ProcessCommand(CommandString:%SIZE(CommandString):OptCtlBlk:%SIZE(OptCtlBl
                      APIError);
 
 if ( %scan( '*EVENTF' : CommandString ) > 0 OR  //All ILE compile commands
-     %scan( '*SRCDBG' : CommandString ) > 0 OR  //OPM RPG and COBOL
-     %scan( '*LSTDBG' : CommandString ) > 0);   //OPM CRTSQLRPG/CBL only supports this
+     %scan( '*SRCDBG' : CommandString ) > 0 OR  //OPM RPG
+     %scan( '*LSTDBG' : CommandString ) > 0);   //OPM CRTSQLRPG only supports this
   if ( Lib = '*CURLIB' );
     Lib = RetrieveCurrrentLibrary();
   endif;
@@ -405,8 +404,6 @@ dcl-proc UpdateEventFile;
     path   pointer value options(*string);
     buf    likeds(statds);
   end-pr;
-
-  // int stat(const char *path, struct stat *buf)
 
   dcl-pr CEEUTCO opdesc;
     Hours         int( 10 );

--- a/iproj.json
+++ b/iproj.json
@@ -1,0 +1,1 @@
+{"curlib": "CRTFRMSTMF"}

--- a/makefile
+++ b/makefile
@@ -5,13 +5,17 @@ TGTRLS=V7R3M0
 
 #----------
 
-all: crtfrmstmf.rpgle crtfrmstmf.pnlgrp crtfrmstmf.cmd
+all: cl_dltf.clle crtfrmstmf.rpgle crtfrmstmf.pnlgrp crtfrmstmf.cmd crtfrmstmf.pgm
 	@echo "Built all"
 
 #----------
 
-%.rpgle:
-	system "CRTBNDRPG PGM($(BIN_LIB)/$*) SRCSTMF('QSOURCE/$*.rpgle') TEXT('$(NAME)') REPLACE(*YES) DBGVIEW($(DBGVIEW)) TGTRLS($(TGTRLS)) TGTCCSID(*JOB)"
+%.pgm:
+	system "CRTPGM PGM($(BIN_LIB)/$*) MODULE($(BIN_LIB)/CRTFRMSTMF $(BIN_LIB)/CL_DLTF)"
+%.rpgle: 
+	system "CRTRPGMOD MODULE($(BIN_LIB)/$*) SRCSTMF('QSOURCE/$*.rpgle') TEXT('$(NAME)') REPLACE(*YES) DBGVIEW($(DBGVIEW)) TGTRLS($(TGTRLS)) TGTCCSID(*JOB)"
+%.clle	:
+	system "CRTCLMOD MODULE($(BIN_LIB)/$*) SRCSTMF('QSOURCE/$*.clle') TEXT('$(NAME)') REPLACE(*YES) DBGVIEW($(DBGVIEW)) TGTRLS($(TGTRLS))"
 
 %.pnlgrp:
 	-system -qi "CRTSRCPF FILE($(BIN_LIB)/QSOURCE) MBR($*) RCDLEN(112)"


### PR DESCRIPTION
CRTCBLPGM does a RCLRSC which cannot be done in QTEMP
The CPF2105 message was issued every time we attempted to delete the old QTEMP/QSOURCE and this made it look like the command was failing with a sev 40 message.  It is not suppressed from the job log so that the command is successful if it the compile succeeds.